### PR TITLE
Improve breadcrumb label

### DIFF
--- a/src/breadcrumb.js
+++ b/src/breadcrumb.js
@@ -140,10 +140,10 @@ var breadcrumb = function(id, config){
 		  cut = url.indexOf(urlDivider);
 
 		  if (cut != -1){
-			breadcrumb[x] = url.slice(0, cut);
+			breadcrumb[x] = decodeURI(url.slice(0, cut));
 			url = url.slice(cut + 1, url.length);
 		  }else{
-			breadcrumb[x] = url;
+			breadcrumb[x] = decodeURI(url);
 			stop = 1;
 		  }
 		  x++;


### PR DESCRIPTION
Used `decodeURI()` to display breadcrumb labels without URL encoding.

E.g. `/riak/kv/3.0/3.0.15/amazon/2%20(graviton%202)/` displayed as `2%20(graviton%202)` and not `2 (graviton 2)`. Now displays `2 (graviton 2)`.